### PR TITLE
[TECH-6730] Add new resource and amend acl condition

### DIFF
--- a/aws_s3_bucket.tf
+++ b/aws_s3_bucket.tf
@@ -14,8 +14,16 @@ resource "aws_s3_bucket_public_access_block" "bucket_access" {
   restrict_public_buckets = var.restrict_public_buckets
 }
 
+resource "aws_s3_bucket_ownership_controls" "example" {
+  bucket = aws_s3_bucket.bucket.id
+
+  rule {
+    object_ownership = var.s3_bucket_ownership
+  }
+}
+
 resource "aws_s3_bucket_acl" "bucket-acl" {
-  count = var.s3_bucket_acl == null || var.s3_bucket_acl == "" || var.s3_bucket_acl == "private" ? 1 : 0
+  count = var.s3_bucket_ownership == "BucketOwnerEnforced" ? 0 : 1
 
   bucket = aws_s3_bucket.bucket.id
   acl    = var.s3_bucket_acl

--- a/aws_s3_bucket.tf
+++ b/aws_s3_bucket.tf
@@ -14,7 +14,7 @@ resource "aws_s3_bucket_public_access_block" "bucket_access" {
   restrict_public_buckets = var.restrict_public_buckets
 }
 
-resource "aws_s3_bucket_ownership_controls" "example" {
+resource "aws_s3_bucket_ownership_controls" "bucket-ownership" {
   bucket = aws_s3_bucket.bucket.id
 
   rule {

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,11 @@ variable "s3_bucket_name" {
   description = "Set the name for the S3 bucket"
 }
 
+variable "s3_bucket_ownership" {
+  description = "Sets ownership of objects uploaded to the bucket and to disable/enable ACLs."
+  default = "BucketOwnerEnforced"
+}
+
 variable "s3_bucket_policy" {
   description = "You can provide a custom bucket policy with this variable"
   default     = null


### PR DESCRIPTION
Any buckets created after Apr 2023, should not be affected by this change (or buckets created via the console, not sure about dates as this isn't stated).

However, majority of the older buckets are set as an object writer for the ownership so this PR would affect those. What we could do is apply this PR and for the buckets out of sync, we manually confirm what the ownership is and apply that in code.

Adding the ownership option below allows for successful builds, option to confirm ACL as well as ownership to allow for that if necessary.