### PR TITLE
Merge caller policy with TLS-deny instead of replacing it (ISO-49)

### DIFF
--- a/aws_s3_bucket.tf
+++ b/aws_s3_bucket.tf
@@ -31,7 +31,7 @@ resource "aws_s3_bucket_acl" "bucket-acl" {
 
 resource "aws_s3_bucket_policy" "bucket-policy" {
   bucket = aws_s3_bucket.bucket.id
-  policy = var.s3_bucket_policy == null || var.s3_bucket_policy == "" ? data.aws_iam_policy_document.bucket-tls-policy-document.json : var.s3_bucket_policy
+  policy = data.aws_iam_policy_document.bucket-tls-policy-document.json
 }
 
 resource "aws_s3_bucket_versioning" "bucket-versioning" {

--- a/aws_s3_bucket_policy.tf
+++ b/aws_s3_bucket_policy.tf
@@ -1,4 +1,7 @@
 data "aws_iam_policy_document" "bucket-tls-policy-document" {
+  # Merge any caller-supplied policy with the mandatory TLS-deny so the
+  # SecureTransport guard can't be dropped by passing a custom s3_bucket_policy.
+  source_policy_documents = (var.s3_bucket_policy == null || var.s3_bucket_policy == "") ? [] : [var.s3_bucket_policy]
 
   statement {
     sid = "SecureTransport"
@@ -20,7 +23,7 @@ data "aws_iam_policy_document" "bucket-tls-policy-document" {
     #values = [1.2]
     #}
 
-    actions = ["S3:*"]
+    actions = ["s3:*"]
 
     resources = [
       "${aws_s3_bucket.bucket.arn}/*",


### PR DESCRIPTION
## What
- `aws_s3_bucket_policy.tf`: merge any caller-supplied `s3_bucket_policy` with the mandatory `SecureTransport` deny via `source_policy_documents`, replacing the previous ternary that swapped it out entirely.
- `aws_s3_bucket.tf`: always emit the merged document.
- Lowercase the policy action `S3:*` → `s3:*`.

## Why
Consumers passing a custom bucket policy (log delivery, cross-account, CloudFront) silently lost the module's built-in TLS-deny, leaving those buckets without HTTPS-in-transit enforcement. This is the module-default half of ISO-49 (enforce HTTPS-only S3 org-wide). The capital `S3:*` is valid to AWS but may not match literal action checks such as Vanta's HTTPS-only S3 test.

## Impact
Non-breaking. Consumers passing `null`/empty get identical output; consumers passing a custom policy now additionally get the TLS-deny appended (Deny-only, so it affects non-TLS requests only). Adopted lazily on each consumer's next apply — do not force-roll dirs with known plan breakage.

## Validation
`terraform fmt`, `terraform init -backend=false`, `terraform validate` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
